### PR TITLE
Copy from template if the entry is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
+# Unreleased
+### Emacs package
+#### Features
+* New user option `diary-manager-template` that you can set to a
+  filename (in Elisp or via `$DIARY_ENTRY_TEMPLATE` environment
+  variable) whose contents will be used to populate newly created
+  entries.
+
 ## 2.0.2 (released 2018-12-14)
 ### Emacs package
 #### Bugs fixed

--- a/README.md
+++ b/README.md
@@ -156,12 +156,19 @@ setting Emacs Lisp variables:
 * `$DIARY_LOCATION` becomes `diary-manager-location`
 * `$DIARY_DATE_FORMAT` becomes `diary-manager-date-format`
 * `$DIARY_ENTRY_EXTENSION` becomes `diary-manager-entry-extension`
+* `$DIARY_TEMPLATE` (not available in the Python version) becomes
+  `diary-manager-template`
 
 If you don't change the extension from `.md`, you will probably want
 to install the package [markdown-mode]. This can be done
 with [`straight.el`][straight.el]:
 
     (straight-use-package 'markdown-mode)
+
+Diary templates are a feature unique to the Emacs version. See
+docstring for the user option, but the short version is that they
+allow you to have custom text inserted by default into each new diary
+entry before you start editing it.
 
 ## Contributor guide
 

--- a/diary-manager.el
+++ b/diary-manager.el
@@ -74,7 +74,9 @@ Defaults to DIARY_ENTRY_EXTENSION, if set."
 
 (defcustom diary-manager-template
   (or (getenv "DIARY_ENTRY_TEMPLATE") "template")
-  "Copy template of dominant questions."
+  "Filename for template to initialize new diary entries with.
+This will have `diary-manager-entry-extension' appended to it,
+and is interpreted relative to `diary-manager-location'."
   :type 'string)
 
 ;;;; Utility functions
@@ -197,12 +199,11 @@ failed\". RESULT is as returned by
               message cmd-string))))
 
 (defun diary-manager--get-filename (date)
-  "Get filename based on DATE."
+  "Get filename based on DATE. Return an absolute filepath."
   (expand-file-name
    (concat (format-time-string diary-manager-date-format date)
            diary-manager-entry-extension)
-   diary-manager-location)
-  )
+   diary-manager-location))
 
 (defun diary-manager--validate-process (pred result)
   "If PRED applied to RESULT returns a message, throw an error.
@@ -505,21 +506,15 @@ Interactively, select DATE using
      (list (funcall diary-manager-read-date-function "[Entry to edit]"))))
   (setq diary-manager--buffer-date date)
   (diary-manager--ensure-location-set)
-  (let (
-        (filename (diary-manager--get-filename diary-manager--buffer-date))
+  (let ((filename (diary-manager--get-filename diary-manager--buffer-date))
         (templatefile
-         (expand-file-name (concat diary-manager-template diary-manager-entry-extension)  diary-manager-location)
-         )
-        )
+         (expand-file-name
+          (concat diary-manager-template diary-manager-entry-extension)
+          diary-manager-location)))
     (find-file filename)
-    (if (file-exists-p templatefile)
-        (unless (file-exists-p filename)
-          (insert-file-contents
-           templatefile
-           nil)
-          )
-      )
-    )
+    (when (and (zerop (buffer-size))
+               (file-exists-p templatefile))
+      (insert-file-contents templatefile nil)))
   (setq diary-manager--buffer-dedicated t)
   (diary-manager-edit-mode +1))
 

--- a/diary-manager.el
+++ b/diary-manager.el
@@ -511,14 +511,14 @@ Interactively, select DATE using
          (expand-file-name (concat diary-manager-template diary-manager-entry-extension)  diary-manager-location)
          )
         )
+    (find-file filename)
     (if (file-exists-p templatefile)
-        (unless (and (file-exists-p filename))
-          (copy-file
+        (unless (file-exists-p filename)
+          (insert-file-contents
            templatefile
-           filename)
+           nil)
           )
       )
-    (find-file filename)
     )
   (setq diary-manager--buffer-dedicated t)
   (diary-manager-edit-mode +1))


### PR DESCRIPTION
This PR is related to the feature request on issue #7 
if `diary-manager-template` is defined, use that specified file as a reference for a new diary entry.

Requirements:
The filename defined on `diary-manager-template` will have to use the same extension defined at `diary-manager-entry-extension`; if it doesn't exist, then the new entry will be empty